### PR TITLE
Fix: include androidx browser

### DIFF
--- a/DemoApp/app/build.gradle
+++ b/DemoApp/app/build.gradle
@@ -118,6 +118,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
     implementation 'androidx.activity:activity:1.9.0'
     implementation 'androidx.activity:activity-ktx:1.9.0'
+    implementation 'androidx.browser:browser:1.8.0'
 
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'androidx.appcompat:appcompat:1.4.0'


### PR DESCRIPTION
## Overview
Add the androidx.browser package to correctly load the Wallet Pass flow in DemoApp. This issue was reported on a Samsung S29 device.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
